### PR TITLE
관광지 단일/전체 조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,12 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+	implementation 'io.swagger.core.v3:swagger-annotations:2.2.21'
+
+	implementation 'org.springframework.data:spring-data-commons:3.2.2'
+
+
+
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'

--- a/src/main/java/com/yummy/yummytrip/attraction/controller/AttractionController.java
+++ b/src/main/java/com/yummy/yummytrip/attraction/controller/AttractionController.java
@@ -1,0 +1,13 @@
+package com.yummy.yummytrip.attraction.controller;
+
+import com.yummy.yummytrip.attraction.service.AttractionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/attraction")
+public class AttractionController {
+    private final AttractionService attractionService;
+}

--- a/src/main/java/com/yummy/yummytrip/attraction/controller/AttractionController.java
+++ b/src/main/java/com/yummy/yummytrip/attraction/controller/AttractionController.java
@@ -1,10 +1,13 @@
 package com.yummy.yummytrip.attraction.controller;
 
+import com.yummy.yummytrip.attraction.model.AttractionSearchRequestDto;
 import com.yummy.yummytrip.attraction.model.GetAttractionResponseDto;
 import com.yummy.yummytrip.attraction.service.AttractionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 
 @RestController
@@ -18,5 +21,12 @@ public class AttractionController {
     @GetMapping("/{attractionId}")
     public ResponseEntity<GetAttractionResponseDto> getAttractionById(@PathVariable("attractionId") Long attractionId){
         return ResponseEntity.ok(attractionService.getAttractionById(attractionId));
+    }
+
+    @GetMapping("/get")
+    public ResponseEntity<List<GetAttractionResponseDto>> getAttractionByFiltering(
+            @RequestBody AttractionSearchRequestDto searchDto
+    ){
+        return ResponseEntity.ok(attractionService.getAttractionByFiltering(searchDto));
     }
 }

--- a/src/main/java/com/yummy/yummytrip/attraction/controller/AttractionController.java
+++ b/src/main/java/com/yummy/yummytrip/attraction/controller/AttractionController.java
@@ -3,6 +3,8 @@ package com.yummy.yummytrip.attraction.controller;
 import com.yummy.yummytrip.attraction.model.AttractionSearchRequestDto;
 import com.yummy.yummytrip.attraction.model.GetAttractionResponseDto;
 import com.yummy.yummytrip.attraction.service.AttractionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -13,16 +15,19 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/attraction")
+@Tag(name = "2. Attraction", description = "관광지 정보 CRUD")
 public class AttractionController {
     private final AttractionService attractionService;
 
     // TODO : 관광지 업데이트
 
+    @Operation(summary = "Get information on just one attraction.", description = "관광지 정보 조회 (단일 아이디)")
     @GetMapping("/{attractionId}")
     public ResponseEntity<GetAttractionResponseDto> getAttractionById(@PathVariable("attractionId") Long attractionId){
         return ResponseEntity.ok(attractionService.getAttractionById(attractionId));
     }
 
+    @Operation(summary = "Get attractions filtered by address and place type.", description = "관광지 정보 조회 (주소, 장소타입, 검색어)")
     @GetMapping("/get")
     public ResponseEntity<List<GetAttractionResponseDto>> getAttractionByFiltering(
             @RequestBody AttractionSearchRequestDto searchDto

--- a/src/main/java/com/yummy/yummytrip/attraction/controller/AttractionController.java
+++ b/src/main/java/com/yummy/yummytrip/attraction/controller/AttractionController.java
@@ -1,7 +1,9 @@
 package com.yummy.yummytrip.attraction.controller;
 
+import com.yummy.yummytrip.attraction.model.GetAttractionResponseDto;
 import com.yummy.yummytrip.attraction.service.AttractionService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 
@@ -10,4 +12,11 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/attraction")
 public class AttractionController {
     private final AttractionService attractionService;
+
+    // TODO : 관광지 업데이트
+
+    @GetMapping("/{attractionId}")
+    public ResponseEntity<GetAttractionResponseDto> getAttractionById(@PathVariable("attractionId") Long attractionId){
+        return ResponseEntity.ok(attractionService.getAttractionById(attractionId));
+    }
 }

--- a/src/main/java/com/yummy/yummytrip/attraction/mapper/AttractionMapper.java
+++ b/src/main/java/com/yummy/yummytrip/attraction/mapper/AttractionMapper.java
@@ -5,11 +5,12 @@ import com.yummy.yummytrip.attraction.model.GetAttractionResponseDto;
 import org.apache.ibatis.annotations.Mapper;
 
 import java.util.List;
+import java.util.Optional;
 
 @Mapper
 public interface AttractionMapper {
 
-    public GetAttractionResponseDto getAttractionById(Long attractionId);
+    public Optional<GetAttractionResponseDto> getAttractionById(Long attractionId);
 
     public List<GetAttractionResponseDto> getAttractionByFiltering(AttractionSearchRequestDto searchDto);
 }

--- a/src/main/java/com/yummy/yummytrip/attraction/mapper/AttractionMapper.java
+++ b/src/main/java/com/yummy/yummytrip/attraction/mapper/AttractionMapper.java
@@ -1,0 +1,15 @@
+package com.yummy.yummytrip.attraction.mapper;
+
+import com.yummy.yummytrip.attraction.model.AttractionSearchRequestDto;
+import com.yummy.yummytrip.attraction.model.GetAttractionResponseDto;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface AttractionMapper {
+
+    public GetAttractionResponseDto getAttractionById(Long attractionId);
+
+    public List<GetAttractionResponseDto> getAttractionByFiltering(AttractionSearchRequestDto searchDto);
+}

--- a/src/main/java/com/yummy/yummytrip/attraction/model/AttractionSearchRequestDto.java
+++ b/src/main/java/com/yummy/yummytrip/attraction/model/AttractionSearchRequestDto.java
@@ -1,0 +1,15 @@
+package com.yummy.yummytrip.attraction.model;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class AttractionSearchRequestDto {
+    private String input;
+    private int sidoCode;
+    private int gugunCode;
+    private int attractionTypeId;
+}

--- a/src/main/java/com/yummy/yummytrip/attraction/model/GetAttractionResponseDto.java
+++ b/src/main/java/com/yummy/yummytrip/attraction/model/GetAttractionResponseDto.java
@@ -1,0 +1,28 @@
+package com.yummy.yummytrip.attraction.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class GetAttractionResponseDto {
+    private Long attractionId;
+    private int gugunCode;
+    private int sidoCode;
+    private Long attractiontypeId;
+    private String title;
+    private String addr1;
+    private String addr2;
+    private String zipcode;
+    private String tel;
+    private String firstImage;
+    private String firstImage2;
+    private int readCount;
+    private BigDecimal latitude;
+    private BigDecimal longitude;
+    private String mLevel;
+}

--- a/src/main/java/com/yummy/yummytrip/attraction/service/AttractionService.java
+++ b/src/main/java/com/yummy/yummytrip/attraction/service/AttractionService.java
@@ -1,17 +1,28 @@
 package com.yummy.yummytrip.attraction.service;
 
 import com.yummy.yummytrip.attraction.mapper.AttractionMapper;
+import com.yummy.yummytrip.attraction.model.AttractionSearchRequestDto;
 import com.yummy.yummytrip.attraction.model.GetAttractionResponseDto;
 import com.yummy.yummytrip.exception.CustomException;
 import com.yummy.yummytrip.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 
 @Service
 @RequiredArgsConstructor
 public class AttractionService {
     private final AttractionMapper mapper;
+
+    public GetAttractionResponseDto getAttractionById(Long attractionId) {
+        return findAttraction(attractionId);
+    }
+
+    public List<GetAttractionResponseDto> getAttractionByFiltering(AttractionSearchRequestDto searchDto) {
+        return mapper.getAttractionByFiltering(searchDto);
+    }
 
     private GetAttractionResponseDto findAttraction(Long attractionId) {
         return mapper.getAttractionById(attractionId)

--- a/src/main/java/com/yummy/yummytrip/attraction/service/AttractionService.java
+++ b/src/main/java/com/yummy/yummytrip/attraction/service/AttractionService.java
@@ -1,0 +1,20 @@
+package com.yummy.yummytrip.attraction.service;
+
+import com.yummy.yummytrip.attraction.mapper.AttractionMapper;
+import com.yummy.yummytrip.attraction.model.GetAttractionResponseDto;
+import com.yummy.yummytrip.exception.CustomException;
+import com.yummy.yummytrip.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+public class AttractionService {
+    private final AttractionMapper mapper;
+
+    private GetAttractionResponseDto findAttraction(Long attractionId) {
+        return mapper.getAttractionById(attractionId)
+                .orElseThrow(() -> new CustomException(ErrorCode.DATA_NOT_EXISTS, "관광지가 존재하지 않습니다. (AttractionService)"));
+    }
+}

--- a/src/main/java/com/yummy/yummytrip/exception/CustomException.java
+++ b/src/main/java/com/yummy/yummytrip/exception/CustomException.java
@@ -1,0 +1,13 @@
+package com.yummy.yummytrip.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException{
+    private ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode, String message){
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/resources/mapper/attraction.xml
+++ b/src/main/resources/mapper/attraction.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.yummy.yummytrip.attraction.mapper.AttractionMapper">
+
+    <!-- public Optional<GetAttractionResponseDto> getAttractionById(Long attractionId); -->
+    <select id="getAttractionById" parameterType="java.lang.Long" resultType="GetAttractionResponseDto">
+        SELECT * FROM attraction_info WHERE attraction_id = #{attractionId}
+    </select>
+
+    <!-- public List<GetAttractionResponseDto> getAttractionByFiltering(AttractionSearchRequestDto searchDto); -->
+    <select id="getAttractionByFiltering" parameterType="AttractionSearchRequestDto" resultType="GetAttractionResponseDto">
+        SELECT * FROM attraction_info
+        WHERE 1=1
+        <if test="sidoCode != 0">
+            AND sido_code = #{sidoCode}
+        </if>
+        <if test="gugunCode != 0">
+            AND gugun_code = #{gugunCode}
+        </if>
+        <if test="attractionTypeId != 0">
+            AND attractiontype_id = #{attractionTypeId}
+        </if>
+        <if test="input != null and input != ''">
+            AND (title LIKE CONCAT('%', #{input}, '%')
+            OR addr1 LIKE CONCAT('%', #{input}, '%')
+            OR addr2 LIKE CONCAT('%', #{input}, '%')
+            OR tel LIKE CONCAT('%', #{input}, '%'))
+        </if>
+    </select>
+</mapper>


### PR DESCRIPTION
## 🗂️ 이슈 연결
- closes: #3 

</br>

## 📌 구현한 API
- 관광지 단일 조회 : `GET /api/attraction/{attractionId}`
- 관광지 필터링 및 전체조회 : `GET /api/attraction/get`

</br>

## 📝 작업 사항
- 관광지 아이디로 단일 관광지 정보 조회
- 시도코드, 구군코드, 장소유형, 검색어로 여러개의 관광지 정보 조회

</br>
