### PR TITLE
회원탈퇴

### DIFF
--- a/src/main/java/com/yummy/yummytrip/exception/ErrorCode.java
+++ b/src/main/java/com/yummy/yummytrip/exception/ErrorCode.java
@@ -6,12 +6,14 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
+
     INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "잘못된 파라미터입니다."),
     INVALID_OPTIONS_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 옵션으로 접근하였습니다."),
     DATA_NOT_EXISTS(HttpStatus.NOT_FOUND, "데이터가 존재하지 않습니다."),
     DATA_EXISTS(HttpStatus.CONFLICT, "데이터가 이미 존재합니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버오류입니다. 관리자에게 문의하세요."),
-    PARSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "데이터 파싱에 실패했습니다.");
+    PARSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "데이터 파싱에 실패했습니다."),
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "잘못된 비밀번호입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/yummy/yummytrip/exception/InvalidPasswordException.java
+++ b/src/main/java/com/yummy/yummytrip/exception/InvalidPasswordException.java
@@ -1,0 +1,10 @@
+package com.yummy.yummytrip.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class InvalidPasswordException extends RuntimeException {
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/com/yummy/yummytrip/filter/LoginFilter.java
+++ b/src/main/java/com/yummy/yummytrip/filter/LoginFilter.java
@@ -58,7 +58,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
         String role = auth.getAuthority();
 
-        String token = jwtUtil.createJwt(username, role, 60*60*10L);
+        String token = jwtUtil.createJwt(username, role, 60*100000L);
 
         response.addHeader("Authorization", "Bearer " + token);
     }

--- a/src/main/java/com/yummy/yummytrip/user/controller/UserController.java
+++ b/src/main/java/com/yummy/yummytrip/user/controller/UserController.java
@@ -2,21 +2,36 @@ package com.yummy.yummytrip.user.controller;
 
 import com.yummy.yummytrip.user.model.JoinDto;
 import com.yummy.yummytrip.user.service.UserService;
+import com.yummy.yummytrip.util.JWTUtil;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
 public class UserController {
     private final UserService service;
+    private final JWTUtil jwtUtil;
 
     @PostMapping("/signup")
     public ResponseEntity signup(@RequestBody JoinDto joinUser){
         service.signUp(joinUser);
         return new ResponseEntity(HttpStatus.CREATED);
+    }
+
+    @PostMapping("/signout")
+    public ResponseEntity signout(HttpServletRequest request, @RequestBody Map<String, String> map){
+        String authorization = request.getHeader("Authorization");
+        String token = authorization.split(" ")[1];
+        String email = jwtUtil.getUsername(token);
+        service.signOut(email, map.get("password"));
+        return new ResponseEntity(HttpStatus.OK);
     }
 }

--- a/src/main/java/com/yummy/yummytrip/user/mapper/UserMapper.java
+++ b/src/main/java/com/yummy/yummytrip/user/mapper/UserMapper.java
@@ -8,4 +8,6 @@ public interface UserMapper {
     public void signUp(UserDto user);
 
     public UserDto findByEmail(String email);
+
+    public void signOut(String email);
 }

--- a/src/main/java/com/yummy/yummytrip/user/service/UserService.java
+++ b/src/main/java/com/yummy/yummytrip/user/service/UserService.java
@@ -3,10 +3,15 @@ package com.yummy.yummytrip.user.service;
 import com.yummy.yummytrip.exception.EmptyDataException;
 import com.yummy.yummytrip.exception.ErrorCode;
 import com.yummy.yummytrip.exception.ExistDataException;
+import com.yummy.yummytrip.exception.InvalidPasswordException;
 import com.yummy.yummytrip.user.mapper.UserMapper;
+import com.yummy.yummytrip.user.model.CustomUserDetails;
 import com.yummy.yummytrip.user.model.JoinDto;
 import com.yummy.yummytrip.user.model.UserDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -33,5 +38,13 @@ public class UserService {
                 .build();
 
         mapper.signUp(user);
+    }
+
+    public void signOut(String email, String password){
+        UserDto findUser = mapper.findByEmail(email);
+        if (!encoder.matches(password, findUser.getPassword())) {
+            throw new InvalidPasswordException(ErrorCode.INVALID_PASSWORD);
+        }
+        mapper.signOut(email);
     }
 }

--- a/src/main/resources/mapper/user.xml
+++ b/src/main/resources/mapper/user.xml
@@ -13,4 +13,8 @@
     <select id="findByEmail" parameterType="String" resultType="UserDto">
         select * from user where email = #{email}
     </select>
+
+    <delete id="signOut" parameterType="String">
+        delete from user where email = #{email}
+    </delete>
 </mapper>


### PR DESCRIPTION
## 🗂️ 이슈 연결
- closes: #5 

</br>

## 📌 구현한 API
- api 설명 : `POST  /signout`

</br>

## 📝 작업 사항
- 인증된 사용자가 회원탈퇴를 할 수 있는 로직을 구현합니다.
- 헤더에 담긴 토큰을 파싱해서 사용자의 아이디를 재입력 받지 않았지만, controller에 로직이 작성되서 역할의 문제가 발생한다 생각합니다. 그래서 securitycontextholder에 저장된 authentication으로부터 값을 가져오는 방식을 적용하려 했지만, 잘 안되서 추후 리팩토링하도록 하겠습니다.

</br>
