### PR TITLE
공지사항 등록, 조회, 수정, 삭제

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 
 	implementation 'org.springframework.data:spring-data-commons:3.2.2'
 
+	implementation 'org.springframework.boot:spring-boot-starter-validation:3.2.1'
 
 
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'

--- a/src/main/java/com/yummy/yummytrip/attraction/model/GetAttractionResponseDto.java
+++ b/src/main/java/com/yummy/yummytrip/attraction/model/GetAttractionResponseDto.java
@@ -24,5 +24,5 @@ public class GetAttractionResponseDto {
     private int readCount;
     private BigDecimal latitude;
     private BigDecimal longitude;
-    private String mLevel;
+    private String mlevel;
 }

--- a/src/main/java/com/yummy/yummytrip/config/SecurityConfig.java
+++ b/src/main/java/com/yummy/yummytrip/config/SecurityConfig.java
@@ -14,6 +14,9 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -41,6 +44,18 @@ public class SecurityConfig {
     }
 
     @Bean
+    public CorsFilter corsFilter() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true);
+        config.addAllowedOriginPattern("*"); // 모든 도메인 허용, 보안에 따라 설정
+        config.addAllowedHeader("*"); // 모든 헤더 허용
+        config.addAllowedMethod("*"); // 모든 HTTP 메서드 허용
+        source.registerCorsConfiguration("/**", config);
+        return new CorsFilter(source);
+    }
+
+    @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
 
@@ -59,6 +74,9 @@ public class SecurityConfig {
                         .anyRequest().authenticated());
         http
                 .addFilterBefore(new JWTFilter(jwtUtil), LoginFilter.class);
+
+        http
+                .addFilter(corsFilter());
 
         //AuthenticationManager()와 JWTUtil 인수 전달
         http

--- a/src/main/java/com/yummy/yummytrip/config/SecurityConfig.java
+++ b/src/main/java/com/yummy/yummytrip/config/SecurityConfig.java
@@ -70,7 +70,10 @@ public class SecurityConfig {
 
         http
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/signup", "/login", "/").permitAll()
+                        .requestMatchers( "/",
+                                "/signup",
+                                "/login",
+                                "/api/notice/**").permitAll()
                         .anyRequest().authenticated());
         http
                 .addFilterBefore(new JWTFilter(jwtUtil), LoginFilter.class);

--- a/src/main/java/com/yummy/yummytrip/config/SecurityConfig.java
+++ b/src/main/java/com/yummy/yummytrip/config/SecurityConfig.java
@@ -55,7 +55,10 @@ public class SecurityConfig {
 
         http
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/signup", "/login", "/").permitAll()
+                        .requestMatchers( "/",
+                                "/signup",
+                                "/login",
+                                "/api/notice/**").permitAll()
                         .anyRequest().authenticated());
         http
                 .addFilterBefore(new JWTFilter(jwtUtil), LoginFilter.class);

--- a/src/main/java/com/yummy/yummytrip/exception/CustomException.java
+++ b/src/main/java/com/yummy/yummytrip/exception/CustomException.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 
 @Getter
 public class CustomException extends RuntimeException{
-    private ErrorCode errorCode;
+    private final ErrorCode errorCode;
 
     public CustomException(ErrorCode errorCode, String message){
         super(message);

--- a/src/main/java/com/yummy/yummytrip/exception/ErrorCode.java
+++ b/src/main/java/com/yummy/yummytrip/exception/ErrorCode.java
@@ -6,12 +6,14 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
+
     INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "잘못된 파라미터입니다."),
     INVALID_OPTIONS_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 옵션으로 접근하였습니다."),
     DATA_NOT_EXISTS(HttpStatus.NOT_FOUND, "데이터가 존재하지 않습니다."),
     DATA_EXISTS(HttpStatus.CONFLICT, "데이터가 이미 존재합니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버오류입니다. 관리자에게 문의하세요."),
-    PARSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "데이터 파싱에 실패했습니다.");
+    PARSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "데이터 파싱에 실패했습니다."),
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "잘못된 비밀번호입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/yummy/yummytrip/exception/ErrorCode.java
+++ b/src/main/java/com/yummy/yummytrip/exception/ErrorCode.java
@@ -3,10 +3,11 @@ package com.yummy.yummytrip.exception;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
-
+    PERMISSION_NOT_GRANTED_ERROR(HttpStatus.BAD_REQUEST, "권한이 없습니다."),
     INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "잘못된 파라미터입니다."),
     INVALID_OPTIONS_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 옵션으로 접근하였습니다."),
     DATA_NOT_EXISTS(HttpStatus.NOT_FOUND, "데이터가 존재하지 않습니다."),

--- a/src/main/java/com/yummy/yummytrip/exception/ErrorResponse.java
+++ b/src/main/java/com/yummy/yummytrip/exception/ErrorResponse.java
@@ -10,4 +10,22 @@ import lombok.RequiredArgsConstructor;
 public class ErrorResponse {
     private final String code;
     private final String message;
+
+    public ErrorResponse(ErrorCode errorCode){
+        this.code = errorCode.toString();
+        this.message = errorCode.getMessage();
+    }
+
+    public ErrorResponse(ErrorCode errorCode, String message){
+        this.code = errorCode.toString();
+        this.message = message;
+    }
+
+    @Override
+    public String toString() {
+        return "ErrorResponse{" +
+                "code='" + code + '\'' +
+                ", message='" + message + '\'' +
+                '}';
+    }
 }

--- a/src/main/java/com/yummy/yummytrip/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/yummy/yummytrip/exception/GlobalExceptionHandler.java
@@ -24,4 +24,13 @@ public class GlobalExceptionHandler {
                 .message(errorCode.getMessage())
                 .build());
     }
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+        ErrorResponse errorResponse = new ErrorResponse(e.getErrorCode(), e.getMessage());
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus()).body(ErrorResponse.builder()
+                .code(e.getErrorCode().toString())
+                .message(errorResponse.getMessage())
+                .build());
+    }
 }

--- a/src/main/java/com/yummy/yummytrip/exception/InvalidPasswordException.java
+++ b/src/main/java/com/yummy/yummytrip/exception/InvalidPasswordException.java
@@ -1,0 +1,10 @@
+package com.yummy.yummytrip.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class InvalidPasswordException extends RuntimeException {
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/com/yummy/yummytrip/filter/LoginFilter.java
+++ b/src/main/java/com/yummy/yummytrip/filter/LoginFilter.java
@@ -66,14 +66,12 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         user.setRole(role);
         user.setUsername(info);
 
-
         String token = jwtUtil.createJwt(username, role, 60*100000L);
-
+        response.addHeader("Authorization", "Bearer " + token);
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
         response.setStatus(HttpServletResponse.SC_OK);
         new ObjectMapper().writeValue(response.getWriter(), user);
-        response.addHeader("Authorization", "Bearer " + token);
     }
 
     //로그인 실패시 실행하는 메소드

--- a/src/main/java/com/yummy/yummytrip/filter/LoginFilter.java
+++ b/src/main/java/com/yummy/yummytrip/filter/LoginFilter.java
@@ -18,7 +18,6 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
-
 public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
     private final AuthenticationManager authenticationManager;
@@ -60,10 +59,13 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         GrantedAuthority auth = iterator.next();
 
         String role = auth.getAuthority();
+        String info = customUserDetails.getInfo();
 
         UserInfoDto user = new UserInfoDto();
-        user.setUsername(username);
+        user.setEmail(username);
         user.setRole(role);
+        user.setUsername(info);
+
 
         String token = jwtUtil.createJwt(username, role, 60*100000L);
 

--- a/src/main/java/com/yummy/yummytrip/filter/LoginFilter.java
+++ b/src/main/java/com/yummy/yummytrip/filter/LoginFilter.java
@@ -1,6 +1,8 @@
 package com.yummy.yummytrip.filter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yummy.yummytrip.user.model.CustomUserDetails;
+import com.yummy.yummytrip.user.model.UserInfoDto;
 import com.yummy.yummytrip.util.JWTUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
@@ -13,6 +15,7 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
 
@@ -45,7 +48,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
     //로그인 성공시 실행하는 메소드 (여기서 JWT를 발급하면 됨)
     @Override
-    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) {
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) throws IOException {
 
         //UserDetailsS
         CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
@@ -58,8 +61,16 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
         String role = auth.getAuthority();
 
+        UserInfoDto user = new UserInfoDto();
+        user.setUsername(username);
+        user.setRole(role);
+
         String token = jwtUtil.createJwt(username, role, 60*100000L);
 
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(HttpServletResponse.SC_OK);
+        new ObjectMapper().writeValue(response.getWriter(), user);
         response.addHeader("Authorization", "Bearer " + token);
     }
 

--- a/src/main/java/com/yummy/yummytrip/filter/LoginFilter.java
+++ b/src/main/java/com/yummy/yummytrip/filter/LoginFilter.java
@@ -58,7 +58,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
         String role = auth.getAuthority();
 
-        String token = jwtUtil.createJwt(username, role, 60*60*10L);
+        String token = jwtUtil.createJwt(username, role, 60*100000L);
 
         response.addHeader("Authorization", "Bearer " + token);
     }

--- a/src/main/java/com/yummy/yummytrip/notice/controller/NoticeController.java
+++ b/src/main/java/com/yummy/yummytrip/notice/controller/NoticeController.java
@@ -44,4 +44,12 @@ public class NoticeController {
     ){
         return ResponseEntity.ok(noticeService.updateNotice(requestDto));
     }
+
+    @DeleteMapping("/delete/{noticeId}")
+    public ResponseEntity<Void> deleteNotice(
+            @PathVariable("noticeId") Long noticeId
+    ){
+        noticeService.deleteNotice(noticeId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/yummy/yummytrip/notice/controller/NoticeController.java
+++ b/src/main/java/com/yummy/yummytrip/notice/controller/NoticeController.java
@@ -2,6 +2,7 @@ package com.yummy.yummytrip.notice.controller;
 
 import com.yummy.yummytrip.notice.model.GetNoticeResponseDto;
 import com.yummy.yummytrip.notice.model.NoticeCreateRequestDto;
+import com.yummy.yummytrip.notice.model.NoticeUpdateRequestDto;
 import com.yummy.yummytrip.notice.service.NoticeService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -35,5 +36,12 @@ public class NoticeController {
     @GetMapping("/get")
     public ResponseEntity<List<GetNoticeResponseDto>> getNotices(){
         return ResponseEntity.ok(noticeService.getNotices());
+    }
+
+    @PostMapping("/upadate")
+    public ResponseEntity<Long> updateNotice(
+            @RequestBody NoticeUpdateRequestDto requestDto
+    ){
+        return ResponseEntity.ok(noticeService.updateNotice(requestDto));
     }
 }

--- a/src/main/java/com/yummy/yummytrip/notice/controller/NoticeController.java
+++ b/src/main/java/com/yummy/yummytrip/notice/controller/NoticeController.java
@@ -6,6 +6,7 @@ import com.yummy.yummytrip.notice.model.NoticeUpdateRequestDto;
 import com.yummy.yummytrip.notice.service.NoticeService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 import lombok.extern.slf4j.Slf4j;
@@ -25,7 +26,7 @@ public class NoticeController {
     @Operation(summary = "Add notice.", description = "공지사항 작성")
     @PostMapping("/add")
     public ResponseEntity<Boolean> createNotice(
-            @RequestBody NoticeCreateRequestDto requestDto
+            @RequestBody @Valid NoticeCreateRequestDto requestDto
     ){
         return ResponseEntity.ok(noticeService.createNotice(requestDto));
     }
@@ -44,10 +45,10 @@ public class NoticeController {
         return ResponseEntity.ok(noticeService.getNotices());
     }
 
-    @Operation(summary = "Update notice By noticeId", description = "공지사항 정보 전체 조회")
-    @PostMapping("/upadate")
+    @Operation(summary = "Update notice By noticeId", description = "공지사항 수정")
+    @PutMapping("/upadate")
     public ResponseEntity<Long> updateNotice(
-            @RequestBody NoticeUpdateRequestDto requestDto
+            @RequestBody @Valid NoticeUpdateRequestDto requestDto
     ){
         noticeService.updateNotice(requestDto);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/yummy/yummytrip/notice/controller/NoticeController.java
+++ b/src/main/java/com/yummy/yummytrip/notice/controller/NoticeController.java
@@ -31,4 +31,9 @@ public class NoticeController {
     ){
         return ResponseEntity.ok(noticeService.getNoticeById(noticeId));
     }
+
+    @GetMapping("/get")
+    public ResponseEntity<List<GetNoticeResponseDto>> getNotices(){
+        return ResponseEntity.ok(noticeService.getNotices());
+    }
 }

--- a/src/main/java/com/yummy/yummytrip/notice/controller/NoticeController.java
+++ b/src/main/java/com/yummy/yummytrip/notice/controller/NoticeController.java
@@ -49,7 +49,8 @@ public class NoticeController {
     public ResponseEntity<Long> updateNotice(
             @RequestBody NoticeUpdateRequestDto requestDto
     ){
-        return ResponseEntity.ok(noticeService.updateNotice(requestDto));
+        noticeService.updateNotice(requestDto);
+        return ResponseEntity.ok().build();
     }
 
     @Operation(summary = "Delete notice By noticeId", description = "공지사항 삭제")

--- a/src/main/java/com/yummy/yummytrip/notice/controller/NoticeController.java
+++ b/src/main/java/com/yummy/yummytrip/notice/controller/NoticeController.java
@@ -1,5 +1,6 @@
 package com.yummy.yummytrip.notice.controller;
 
+import com.yummy.yummytrip.notice.model.GetNoticeResponseDto;
 import com.yummy.yummytrip.notice.model.NoticeCreateRequestDto;
 import com.yummy.yummytrip.notice.service.NoticeService;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -22,5 +23,12 @@ public class NoticeController {
             @RequestBody NoticeCreateRequestDto requestDto
     ){
         return ResponseEntity.ok(noticeService.createNotice(requestDto));
+    }
+
+    @GetMapping("/{noticeId}")
+    public ResponseEntity<GetNoticeResponseDto> getNoticeById(
+            @PathVariable("noticeId") Long noticeId
+    ){
+        return ResponseEntity.ok(noticeService.getNoticeById(noticeId));
     }
 }

--- a/src/main/java/com/yummy/yummytrip/notice/controller/NoticeController.java
+++ b/src/main/java/com/yummy/yummytrip/notice/controller/NoticeController.java
@@ -4,12 +4,15 @@ import com.yummy.yummytrip.notice.model.GetNoticeResponseDto;
 import com.yummy.yummytrip.notice.model.NoticeCreateRequestDto;
 import com.yummy.yummytrip.notice.model.NoticeUpdateRequestDto;
 import com.yummy.yummytrip.notice.service.NoticeService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @Slf4j
@@ -19,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 public class NoticeController {
     private final NoticeService noticeService;
 
+    @Operation(summary = "Add notice.", description = "공지사항 작성")
     @PostMapping("/add")
     public ResponseEntity<Boolean> createNotice(
             @RequestBody NoticeCreateRequestDto requestDto
@@ -26,6 +30,7 @@ public class NoticeController {
         return ResponseEntity.ok(noticeService.createNotice(requestDto));
     }
 
+    @Operation(summary = "Get information on just one notice.", description = "공지사항 정보 조회 (단일 아이디)")
     @GetMapping("/{noticeId}")
     public ResponseEntity<GetNoticeResponseDto> getNoticeById(
             @PathVariable("noticeId") Long noticeId
@@ -33,11 +38,13 @@ public class NoticeController {
         return ResponseEntity.ok(noticeService.getNoticeById(noticeId));
     }
 
+    @Operation(summary = "Get all notices.", description = "공지사항 정보 전체 조회")
     @GetMapping("/get")
     public ResponseEntity<List<GetNoticeResponseDto>> getNotices(){
         return ResponseEntity.ok(noticeService.getNotices());
     }
 
+    @Operation(summary = "Update notice By noticeId", description = "공지사항 정보 전체 조회")
     @PostMapping("/upadate")
     public ResponseEntity<Long> updateNotice(
             @RequestBody NoticeUpdateRequestDto requestDto
@@ -45,6 +52,7 @@ public class NoticeController {
         return ResponseEntity.ok(noticeService.updateNotice(requestDto));
     }
 
+    @Operation(summary = "Delete notice By noticeId", description = "공지사항 삭제")
     @DeleteMapping("/delete/{noticeId}")
     public ResponseEntity<Void> deleteNotice(
             @PathVariable("noticeId") Long noticeId

--- a/src/main/java/com/yummy/yummytrip/notice/controller/NoticeController.java
+++ b/src/main/java/com/yummy/yummytrip/notice/controller/NoticeController.java
@@ -1,9 +1,12 @@
 package com.yummy.yummytrip.notice.controller;
 
+import com.yummy.yummytrip.notice.model.NoticeCreateRequestDto;
+import com.yummy.yummytrip.notice.service.NoticeService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -12,5 +15,12 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/notice")
 @Tag(name = "2. Notice", description = "공지사항 정보 CRUD")
 public class NoticeController {
+    private final NoticeService noticeService;
 
+    @PostMapping("/add")
+    public ResponseEntity<Boolean> createNotice(
+            @RequestBody NoticeCreateRequestDto requestDto
+    ){
+        return ResponseEntity.ok(noticeService.createNotice(requestDto));
+    }
 }

--- a/src/main/java/com/yummy/yummytrip/notice/controller/NoticeController.java
+++ b/src/main/java/com/yummy/yummytrip/notice/controller/NoticeController.java
@@ -1,0 +1,16 @@
+package com.yummy.yummytrip.notice.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/api/notice")
+@Tag(name = "2. Notice", description = "공지사항 정보 CRUD")
+public class NoticeController {
+
+}

--- a/src/main/java/com/yummy/yummytrip/notice/mapper/NoticeMapper.java
+++ b/src/main/java/com/yummy/yummytrip/notice/mapper/NoticeMapper.java
@@ -1,0 +1,19 @@
+package com.yummy.yummytrip.notice.mapper;
+
+import com.yummy.yummytrip.notice.model.GetNoticeResponseDto;
+import com.yummy.yummytrip.notice.model.NoticeCreateRequestDto;
+import com.yummy.yummytrip.notice.model.NoticeUpdateRequestDto;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+@Mapper
+public interface NoticeMapper {
+    int insertNotice(NoticeCreateRequestDto requestDto);
+    Optional<GetNoticeResponseDto> getNoticeById(@Param("noticeId") Long noticeId);
+    List<GetNoticeResponseDto> selectAllNotices();
+    void updateNotice(NoticeUpdateRequestDto requestDto);
+    void deleteNotice(@Param("noticeId") Long noticeId);
+}

--- a/src/main/java/com/yummy/yummytrip/notice/mapper/NoticeMapper.java
+++ b/src/main/java/com/yummy/yummytrip/notice/mapper/NoticeMapper.java
@@ -1,7 +1,6 @@
 package com.yummy.yummytrip.notice.mapper;
 
 import com.yummy.yummytrip.notice.model.GetNoticeResponseDto;
-import com.yummy.yummytrip.notice.model.NoticeCreateMapperDto;
 import com.yummy.yummytrip.notice.model.NoticeUpdateRequestDto;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;

--- a/src/main/java/com/yummy/yummytrip/notice/mapper/NoticeMapper.java
+++ b/src/main/java/com/yummy/yummytrip/notice/mapper/NoticeMapper.java
@@ -1,7 +1,7 @@
 package com.yummy.yummytrip.notice.mapper;
 
 import com.yummy.yummytrip.notice.model.GetNoticeResponseDto;
-import com.yummy.yummytrip.notice.model.NoticeCreateRequestDto;
+import com.yummy.yummytrip.notice.model.NoticeCreateMapperDto;
 import com.yummy.yummytrip.notice.model.NoticeUpdateRequestDto;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -11,7 +11,7 @@ import java.util.Optional;
 
 @Mapper
 public interface NoticeMapper {
-    int insertNotice(NoticeCreateRequestDto requestDto);
+    int insertNotice(GetNoticeResponseDto mapperDto);
     Optional<GetNoticeResponseDto> getNoticeById(@Param("noticeId") Long noticeId);
     List<GetNoticeResponseDto> selectAllNotices();
     void updateNotice(NoticeUpdateRequestDto requestDto);

--- a/src/main/java/com/yummy/yummytrip/notice/model/GetNoticeResponseDto.java
+++ b/src/main/java/com/yummy/yummytrip/notice/model/GetNoticeResponseDto.java
@@ -1,14 +1,14 @@
 package com.yummy.yummytrip.notice.model;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
-@Data
+@Getter
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 public class GetNoticeResponseDto {
     private Long noticeId;
     private Long userId;
@@ -16,4 +16,5 @@ public class GetNoticeResponseDto {
     private String content;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
+
 }

--- a/src/main/java/com/yummy/yummytrip/notice/model/GetNoticeResponseDto.java
+++ b/src/main/java/com/yummy/yummytrip/notice/model/GetNoticeResponseDto.java
@@ -1,0 +1,19 @@
+package com.yummy.yummytrip.notice.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class GetNoticeResponseDto {
+    private Long noticeId;
+    private Long userId;
+    private String title;
+    private String content;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/yummy/yummytrip/notice/model/NoticeCreateMapperDto.java
+++ b/src/main/java/com/yummy/yummytrip/notice/model/NoticeCreateMapperDto.java
@@ -1,0 +1,20 @@
+package com.yummy.yummytrip.notice.model;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class NoticeCreateMapperDto {
+    private String title;
+    private String content;
+    private Long userId;
+
+    public NoticeCreateMapperDto(NoticeCreateRequestDto requestDto, Long userId) {
+        this.title = requestDto.getTitle();
+        this.content = requestDto.getContent();
+        this.userId = userId;
+    }
+}

--- a/src/main/java/com/yummy/yummytrip/notice/model/NoticeCreateRequestDto.java
+++ b/src/main/java/com/yummy/yummytrip/notice/model/NoticeCreateRequestDto.java
@@ -1,0 +1,14 @@
+package com.yummy.yummytrip.notice.model;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class NoticeCreateRequestDto {
+    private Long userId;
+    private String title;
+    private String content;
+}

--- a/src/main/java/com/yummy/yummytrip/notice/model/NoticeCreateRequestDto.java
+++ b/src/main/java/com/yummy/yummytrip/notice/model/NoticeCreateRequestDto.java
@@ -1,5 +1,6 @@
 package com.yummy.yummytrip.notice.model;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -8,7 +9,8 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class NoticeCreateRequestDto {
-    private Long userId;
+    @NotBlank(message = "제목은 필수입니다.")
     private String title;
+    @NotBlank(message = "내용은 필수입니다.")
     private String content;
 }

--- a/src/main/java/com/yummy/yummytrip/notice/model/NoticeUpdateRequestDto.java
+++ b/src/main/java/com/yummy/yummytrip/notice/model/NoticeUpdateRequestDto.java
@@ -1,5 +1,6 @@
 package com.yummy.yummytrip.notice.model;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -8,6 +9,7 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class NoticeUpdateRequestDto {
+    @NotNull(message = "공지사항을 수정하기 위해서는 공지사항 아이디가 필요합니다.")
     private Long noticeId;
     private String title;
     private String content;

--- a/src/main/java/com/yummy/yummytrip/notice/model/NoticeUpdateRequestDto.java
+++ b/src/main/java/com/yummy/yummytrip/notice/model/NoticeUpdateRequestDto.java
@@ -1,0 +1,4 @@
+package com.yummy.yummytrip.notice.model;
+
+public class NoticeUpdateRequestDto {
+}

--- a/src/main/java/com/yummy/yummytrip/notice/model/NoticeUpdateRequestDto.java
+++ b/src/main/java/com/yummy/yummytrip/notice/model/NoticeUpdateRequestDto.java
@@ -1,4 +1,14 @@
 package com.yummy.yummytrip.notice.model;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
 public class NoticeUpdateRequestDto {
+    private Long noticeId;
+    private String title;
+    private String content;
 }

--- a/src/main/java/com/yummy/yummytrip/notice/service/NoticeService.java
+++ b/src/main/java/com/yummy/yummytrip/notice/service/NoticeService.java
@@ -40,10 +40,12 @@ public class NoticeService {
     }
 
     public void updateNotice(NoticeUpdateRequestDto requestDto) {
+        findNotice(requestDto.getNoticeId());
         noticeMapper.updateNotice(requestDto);
     }
 
     public void deleteNotice(Long noticeId) {
+        findNotice(noticeId);
         noticeMapper.deleteNotice(noticeId);
     }
 

--- a/src/main/java/com/yummy/yummytrip/notice/service/NoticeService.java
+++ b/src/main/java/com/yummy/yummytrip/notice/service/NoticeService.java
@@ -8,6 +8,8 @@ import com.yummy.yummytrip.notice.model.NoticeCreateRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 
 @Service
 @RequiredArgsConstructor
@@ -16,6 +18,14 @@ public class NoticeService {
 
     public Boolean createNotice(NoticeCreateRequestDto requestDto) {
         return mapper.insertNotice(requestDto) > 0;
+    }
+
+    public GetNoticeResponseDto getNoticeById(Long noticeId) {
+        return findNotice(noticeId);
+    }
+
+    public List<GetNoticeResponseDto> getNotices() {
+        return mapper.selectAllNotices();
     }
 
     private GetNoticeResponseDto findNotice(Long noticeId) {

--- a/src/main/java/com/yummy/yummytrip/notice/service/NoticeService.java
+++ b/src/main/java/com/yummy/yummytrip/notice/service/NoticeService.java
@@ -4,6 +4,7 @@ import com.yummy.yummytrip.exception.CustomException;
 import com.yummy.yummytrip.exception.ErrorCode;
 import com.yummy.yummytrip.notice.mapper.NoticeMapper;
 import com.yummy.yummytrip.notice.model.GetNoticeResponseDto;
+import com.yummy.yummytrip.notice.model.NoticeCreateRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -12,6 +13,10 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class NoticeService {
     private final NoticeMapper mapper;
+
+    public Boolean createNotice(NoticeCreateRequestDto requestDto) {
+        return mapper.insertNotice(requestDto) > 0;
+    }
 
     private GetNoticeResponseDto findNotice(Long noticeId) {
         return mapper.getNoticeById(noticeId)

--- a/src/main/java/com/yummy/yummytrip/notice/service/NoticeService.java
+++ b/src/main/java/com/yummy/yummytrip/notice/service/NoticeService.java
@@ -5,6 +5,7 @@ import com.yummy.yummytrip.exception.ErrorCode;
 import com.yummy.yummytrip.notice.mapper.NoticeMapper;
 import com.yummy.yummytrip.notice.model.GetNoticeResponseDto;
 import com.yummy.yummytrip.notice.model.NoticeCreateRequestDto;
+import com.yummy.yummytrip.notice.model.NoticeUpdateRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -26,6 +27,14 @@ public class NoticeService {
 
     public List<GetNoticeResponseDto> getNotices() {
         return mapper.selectAllNotices();
+    }
+
+    public void updateNotice(NoticeUpdateRequestDto requestDto) {
+        mapper.updateNotice(requestDto);
+    }
+
+    public void deleteNotice(Long noticeId) {
+        mapper.deleteNotice(noticeId);
     }
 
     private GetNoticeResponseDto findNotice(Long noticeId) {

--- a/src/main/java/com/yummy/yummytrip/notice/service/NoticeService.java
+++ b/src/main/java/com/yummy/yummytrip/notice/service/NoticeService.java
@@ -1,0 +1,20 @@
+package com.yummy.yummytrip.notice.service;
+
+import com.yummy.yummytrip.exception.CustomException;
+import com.yummy.yummytrip.exception.ErrorCode;
+import com.yummy.yummytrip.notice.mapper.NoticeMapper;
+import com.yummy.yummytrip.notice.model.GetNoticeResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+public class NoticeService {
+    private final NoticeMapper mapper;
+
+    private GetNoticeResponseDto findNotice(Long noticeId) {
+        return mapper.getNoticeById(noticeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.DATA_NOT_EXISTS, "공지사항이 존재하지 않습니다. (NoticeService)"));
+    }
+}

--- a/src/main/java/com/yummy/yummytrip/notice/service/NoticeService.java
+++ b/src/main/java/com/yummy/yummytrip/notice/service/NoticeService.java
@@ -6,6 +6,8 @@ import com.yummy.yummytrip.notice.mapper.NoticeMapper;
 import com.yummy.yummytrip.notice.model.GetNoticeResponseDto;
 import com.yummy.yummytrip.notice.model.NoticeCreateRequestDto;
 import com.yummy.yummytrip.notice.model.NoticeUpdateRequestDto;
+import com.yummy.yummytrip.user.mapper.UserMapper;
+import com.yummy.yummytrip.user.model.UserDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,10 +17,18 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class NoticeService {
-    private final NoticeMapper mapper;
+    private final NoticeMapper noticeMapper;
+    private final UserMapper userMapper;
 
-    public Boolean createNotice(NoticeCreateRequestDto requestDto) {
-        return mapper.insertNotice(requestDto) > 0;
+    public Boolean createNotice(NoticeCreateRequestDto requestDto, String email) {
+        UserDto userDto = userMapper.findByEmail(email);
+        GetNoticeResponseDto mapperDto = GetNoticeResponseDto
+                .builder()
+                .title(requestDto.getTitle())
+                .content(requestDto.getContent())
+                .userId(userDto.getUserId())
+                .build();
+        return noticeMapper.insertNotice(mapperDto) > 0;
     }
 
     public GetNoticeResponseDto getNoticeById(Long noticeId) {
@@ -26,19 +36,19 @@ public class NoticeService {
     }
 
     public List<GetNoticeResponseDto> getNotices() {
-        return mapper.selectAllNotices();
+        return noticeMapper.selectAllNotices();
     }
 
     public void updateNotice(NoticeUpdateRequestDto requestDto) {
-        mapper.updateNotice(requestDto);
+        noticeMapper.updateNotice(requestDto);
     }
 
     public void deleteNotice(Long noticeId) {
-        mapper.deleteNotice(noticeId);
+        noticeMapper.deleteNotice(noticeId);
     }
 
     private GetNoticeResponseDto findNotice(Long noticeId) {
-        return mapper.getNoticeById(noticeId)
+        return noticeMapper.getNoticeById(noticeId)
                 .orElseThrow(() -> new CustomException(ErrorCode.DATA_NOT_EXISTS, "공지사항이 존재하지 않습니다. (NoticeService)"));
     }
 }

--- a/src/main/java/com/yummy/yummytrip/user/controller/UserController.java
+++ b/src/main/java/com/yummy/yummytrip/user/controller/UserController.java
@@ -7,27 +7,26 @@ import com.yummy.yummytrip.user.service.UserService;
 import com.yummy.yummytrip.util.JWTUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import org.apache.catalina.User;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("api/user")
 public class UserController {
     private final UserService service;
     private final JWTUtil jwtUtil;
 
-    @PostMapping("/signup")
+    @PostMapping("/join")
     public ResponseEntity signup(@RequestBody JoinDto joinUser) {
         service.signUp(joinUser);
         return new ResponseEntity(HttpStatus.CREATED);
     }
 
-    @PostMapping("/signout")
+    @PostMapping("/leave")
     public ResponseEntity signout(HttpServletRequest request, @RequestBody Map<String, String> map){
         String authorization = request.getHeader("Authorization");
         String token = authorization.split(" ")[1];
@@ -36,7 +35,7 @@ public class UserController {
         return new ResponseEntity(HttpStatus.OK);
     }
   
-    @PatchMapping("/user")
+    @PatchMapping("/update")
     public ResponseEntity modify(HttpServletRequest request, @RequestBody UpdateDto updateDto) {
         String authorization = request.getHeader("Authorization");
         String token = authorization.split(" ")[1];
@@ -46,12 +45,12 @@ public class UserController {
         return new ResponseEntity(HttpStatus.OK);
     }
 
-    @GetMapping("/user/email")
+    @GetMapping("/email")
     public String findEmail(@RequestBody UserDto userDto) {
         return service.findEmail(userDto);
     }
 
-    @GetMapping("/user/password")
+    @GetMapping("/password")
     public String findPassword(@RequestBody UserDto userDto) {
         return service.findPassword(userDto);
     }

--- a/src/main/java/com/yummy/yummytrip/user/controller/UserController.java
+++ b/src/main/java/com/yummy/yummytrip/user/controller/UserController.java
@@ -2,21 +2,36 @@ package com.yummy.yummytrip.user.controller;
 
 import com.yummy.yummytrip.user.model.JoinDto;
 import com.yummy.yummytrip.user.service.UserService;
+import com.yummy.yummytrip.util.JWTUtil;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
 public class UserController {
     private final UserService service;
+    private final JWTUtil jwtUtil;
 
     @PostMapping("/signup")
     public ResponseEntity signup(@RequestBody JoinDto joinUser){
         service.signUp(joinUser);
         return new ResponseEntity(HttpStatus.CREATED);
+    }
+
+    @PostMapping("/signout")
+    public ResponseEntity signout(HttpServletRequest request, @RequestBody Map<String, String> map){
+        String authorization = request.getHeader("Authorization");
+        String token = authorization.split(" ")[1];
+        String email = jwtUtil.getUsername(token);
+        service.signOut(email, map.get("password"));
+        return new ResponseEntity(HttpStatus.OK);
     }
 }

--- a/src/main/java/com/yummy/yummytrip/user/controller/UserController.java
+++ b/src/main/java/com/yummy/yummytrip/user/controller/UserController.java
@@ -1,22 +1,48 @@
 package com.yummy.yummytrip.user.controller;
 
 import com.yummy.yummytrip.user.model.JoinDto;
+import com.yummy.yummytrip.user.model.UpdateDto;
+import com.yummy.yummytrip.user.model.UserDto;
 import com.yummy.yummytrip.user.service.UserService;
+import com.yummy.yummytrip.util.JWTUtil;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.apache.catalina.User;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
 public class UserController {
     private final UserService service;
+    private final JWTUtil jwtUtil;
 
     @PostMapping("/signup")
-    public ResponseEntity signup(@RequestBody JoinDto joinUser){
+    public ResponseEntity signup(@RequestBody JoinDto joinUser) {
         service.signUp(joinUser);
         return new ResponseEntity(HttpStatus.CREATED);
+    }
+
+    @PatchMapping("/user")
+    public ResponseEntity modify(HttpServletRequest request, @RequestBody UpdateDto updateDto) {
+        String authorization = request.getHeader("Authorization");
+        String token = authorization.split(" ")[1];
+        String email = jwtUtil.getUsername(token);
+        updateDto.setEmail(email);
+        service.modify(updateDto);
+        return new ResponseEntity(HttpStatus.OK);
+    }
+
+    @GetMapping("/user/email")
+    public String findEmail(@RequestBody UserDto userDto) {
+        return service.findEmail(userDto);
+    }
+
+    @GetMapping("/user/password")
+    public String findPassword(@RequestBody UserDto userDto) {
+        return service.findPassword(userDto);
     }
 }

--- a/src/main/java/com/yummy/yummytrip/user/mapper/UserMapper.java
+++ b/src/main/java/com/yummy/yummytrip/user/mapper/UserMapper.java
@@ -8,4 +8,6 @@ public interface UserMapper {
     public void signUp(UserDto user);
 
     public UserDto findByEmail(String email);
+
+    public void signOut(String email);
 }

--- a/src/main/java/com/yummy/yummytrip/user/mapper/UserMapper.java
+++ b/src/main/java/com/yummy/yummytrip/user/mapper/UserMapper.java
@@ -1,5 +1,6 @@
 package com.yummy.yummytrip.user.mapper;
 
+import com.yummy.yummytrip.user.model.UpdateDto;
 import com.yummy.yummytrip.user.model.UserDto;
 import org.apache.ibatis.annotations.Mapper;
 
@@ -8,4 +9,12 @@ public interface UserMapper {
     public void signUp(UserDto user);
 
     public UserDto findByEmail(String email);
+
+    void update(UpdateDto updateDto);
+
+    UserDto findEmail(UserDto userDto);
+
+    UserDto findPassword(UserDto userDto);
+
+    void updatePassword(UserDto findUser);
 }

--- a/src/main/java/com/yummy/yummytrip/user/model/CustomUserDetails.java
+++ b/src/main/java/com/yummy/yummytrip/user/model/CustomUserDetails.java
@@ -39,6 +39,10 @@ public class CustomUserDetails implements UserDetails {
         return user.getEmail();
     }
 
+    public String getInfo(){
+        return user.getUsername();
+    }
+
     @Override
     public boolean isAccountNonExpired() {
         return true;

--- a/src/main/java/com/yummy/yummytrip/user/model/JoinDto.java
+++ b/src/main/java/com/yummy/yummytrip/user/model/JoinDto.java
@@ -9,7 +9,6 @@ import java.time.LocalDate;
 
 @Getter
 @Setter
-@NoArgsConstructor
 public class JoinDto {
     private String username;
     private String email;

--- a/src/main/java/com/yummy/yummytrip/user/model/UpdateDto.java
+++ b/src/main/java/com/yummy/yummytrip/user/model/UpdateDto.java
@@ -1,0 +1,16 @@
+package com.yummy.yummytrip.user.model;
+
+import com.yummy.yummytrip.util.Role;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+@Getter
+@Setter
+public class UpdateDto {
+    private String username;
+    private String email;
+    private String password;
+    private LocalDate birth;
+    private Role usertype;
+}

--- a/src/main/java/com/yummy/yummytrip/user/model/UserInfoDto.java
+++ b/src/main/java/com/yummy/yummytrip/user/model/UserInfoDto.java
@@ -1,0 +1,11 @@
+package com.yummy.yummytrip.user.model;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserInfoDto {
+    private String username;
+    private String role;
+}

--- a/src/main/java/com/yummy/yummytrip/user/model/UserInfoDto.java
+++ b/src/main/java/com/yummy/yummytrip/user/model/UserInfoDto.java
@@ -6,6 +6,7 @@ import lombok.Setter;
 @Getter
 @Setter
 public class UserInfoDto {
+    private String email;
     private String username;
     private String role;
 }

--- a/src/main/java/com/yummy/yummytrip/user/service/UserService.java
+++ b/src/main/java/com/yummy/yummytrip/user/service/UserService.java
@@ -5,10 +5,16 @@ import com.yummy.yummytrip.exception.ErrorCode;
 import com.yummy.yummytrip.exception.ExistDataException;
 import com.yummy.yummytrip.user.mapper.UserMapper;
 import com.yummy.yummytrip.user.model.JoinDto;
+import com.yummy.yummytrip.user.model.UpdateDto;
 import com.yummy.yummytrip.user.model.UserDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.util.Random;
+
+import static com.yummy.yummytrip.util.PasswordUtils.DATA_FOR_RANDOM_STRING;
+import static com.yummy.yummytrip.util.PasswordUtils.LENGTH;
 
 @Service
 @RequiredArgsConstructor
@@ -33,5 +39,43 @@ public class UserService {
                 .build();
 
         mapper.signUp(user);
+    }
+
+    public void modify(UpdateDto updateDto) {
+        updateDto.setPassword(encoder.encode(updateDto.getPassword()));
+        mapper.update(updateDto);
+    }
+
+    public String findEmail(UserDto userDto) {
+        UserDto findUser = mapper.findEmail(userDto);
+
+        if (findUser == null) {
+            throw new EmptyDataException(ErrorCode.DATA_NOT_EXISTS);
+        }
+
+        return findUser.getEmail();
+    }
+
+    public String findPassword(UserDto userDto) {
+        UserDto findUser = mapper.findPassword(userDto);
+        if (findUser == null) {
+            throw new EmptyDataException(ErrorCode.DATA_NOT_EXISTS);
+        }
+        String newPassword = generateTemporaryPassword();
+        findUser.setPassword(encoder.encode(generateTemporaryPassword()));
+        mapper.updatePassword(findUser);
+        return newPassword;
+    }
+
+    public String generateTemporaryPassword() {
+        Random random = new Random();
+        StringBuilder sb = new StringBuilder(LENGTH);
+
+        for (int i = 0; i < LENGTH; i++) {
+            int rndCharAt = random.nextInt(DATA_FOR_RANDOM_STRING.length());
+            char rndChar = DATA_FOR_RANDOM_STRING.charAt(rndCharAt);
+            sb.append(rndChar);
+        }
+        return sb.toString();
     }
 }

--- a/src/main/java/com/yummy/yummytrip/user/service/UserService.java
+++ b/src/main/java/com/yummy/yummytrip/user/service/UserService.java
@@ -3,10 +3,15 @@ package com.yummy.yummytrip.user.service;
 import com.yummy.yummytrip.exception.EmptyDataException;
 import com.yummy.yummytrip.exception.ErrorCode;
 import com.yummy.yummytrip.exception.ExistDataException;
+import com.yummy.yummytrip.exception.InvalidPasswordException;
 import com.yummy.yummytrip.user.mapper.UserMapper;
+import com.yummy.yummytrip.user.model.CustomUserDetails;
 import com.yummy.yummytrip.user.model.JoinDto;
 import com.yummy.yummytrip.user.model.UserDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -33,5 +38,13 @@ public class UserService {
                 .build();
 
         mapper.signUp(user);
+    }
+
+    public void signOut(String email, String password){
+        UserDto findUser = mapper.findByEmail(email);
+        if (!encoder.matches(password, findUser.getPassword())) {
+            throw new InvalidPasswordException(ErrorCode.INVALID_PASSWORD);
+        }
+        mapper.signOut(email);
     }
 }

--- a/src/main/java/com/yummy/yummytrip/util/PasswordUtils.java
+++ b/src/main/java/com/yummy/yummytrip/util/PasswordUtils.java
@@ -1,0 +1,9 @@
+package com.yummy.yummytrip.util;
+
+public class PasswordUtils {
+    public static final String CHAR_LOWER = "abcdefghijklmnopqrstuvwxyz";
+    public static final String CHAR_UPPER = CHAR_LOWER.toUpperCase();
+    public static final String NUMBER = "0123456789";
+    public static final String DATA_FOR_RANDOM_STRING = CHAR_LOWER + CHAR_UPPER + NUMBER;
+    public static final int LENGTH = 12;
+}

--- a/src/main/resources/mapper/attraction.xml
+++ b/src/main/resources/mapper/attraction.xml
@@ -3,14 +3,31 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="com.yummy.yummytrip.attraction.mapper.AttractionMapper">
+    <resultMap id="attractionResultMap" type="GetAttractionResponseDto">
+        <id property="attractionId" column="attraction_id"/>
+        <result property="gugunCode" column="gugun_code"/>
+        <result property="sidoCode" column="sido_code"/>
+        <result property="attractiontypeId" column="attractiontype_id"/>
+        <result property="title" column="title"/>
+        <result property="addr1" column="addr1"/>
+        <result property="addr2" column="addr2"/>
+        <result property="zipcode" column="zipcode"/>
+        <result property="tel" column="tel"/>
+        <result property="firstImage" column="first_image"/>
+        <result property="firstImage2" column="first_image2"/>
+        <result property="readCount" column="readcount"/>
+        <result property="latitude" column="latitude"/>
+        <result property="longitude" column="longitude"/>
+        <result property="mlevel" column="mlevel"/>
+    </resultMap>
 
     <!-- public Optional<GetAttractionResponseDto> getAttractionById(Long attractionId); -->
-    <select id="getAttractionById" parameterType="java.lang.Long" resultType="GetAttractionResponseDto">
+    <select id="getAttractionById" parameterType="java.lang.Long" resultMap="attractionResultMap">
         SELECT * FROM attraction_info WHERE attraction_id = #{attractionId}
     </select>
 
     <!-- public List<GetAttractionResponseDto> getAttractionByFiltering(AttractionSearchRequestDto searchDto); -->
-    <select id="getAttractionByFiltering" parameterType="AttractionSearchRequestDto" resultType="GetAttractionResponseDto">
+    <select id="getAttractionByFiltering" parameterType="AttractionSearchRequestDto" resultMap="attractionResultMap">
         SELECT * FROM attraction_info
         WHERE 1=1
         <if test="sidoCode != 0">

--- a/src/main/resources/mapper/notice.xml
+++ b/src/main/resources/mapper/notice.xml
@@ -4,7 +4,8 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="com.yummy.yummytrip.notice.mapper.NoticeMapper">
-    <resultMap id="NoticeResultMap" type="com.yummy.yummytrip.notice.model.GetNoticeResponseDto">
+
+    <resultMap id="NoticeSearchResultMap" type="com.yummy.yummytrip.notice.model.GetNoticeResponseDto" >
         <id column="notice_id" property="noticeId"/>
         <result column="user_id" property="userId"/>
         <result column="title" property="title"/>
@@ -13,18 +14,18 @@
         <result column="modifiedAt" property="modifiedAt"/>
     </resultMap>
 
-    <insert id="insertNotice" parameterType="com.yummy.yummytrip.notice.model.NoticeCreateRequestDto">
+    <insert id="insertNotice" parameterType="com.yummy.yummytrip.notice.model.GetNoticeResponseDto" >
         INSERT INTO notice (user_id, title, content, createdAt, modifiedAt)
         VALUES (#{userId}, #{title}, #{content}, NOW(), NOW())
     </insert>
 
-    <select id="getNoticeById" parameterType="long" resultMap="NoticeResultMap">
+    <select id="getNoticeById" parameterType="long" resultMap="NoticeSearchResultMap">
         SELECT notice_id, user_id, title, content, createdAt, modifiedAt
         FROM notice
         WHERE notice_id = #{noticeId}
     </select>
 
-    <select id="selectAllNotices" resultMap="NoticeResultMap">
+    <select id="selectAllNotices" resultMap="NoticeSearchResultMap">
         SELECT notice_id, user_id, title, content, createdAt, modifiedAt
         FROM notice
         ORDER BY createdAt DESC

--- a/src/main/resources/mapper/notice.xml
+++ b/src/main/resources/mapper/notice.xml
@@ -4,18 +4,27 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="com.yummy.yummytrip.notice.mapper.NoticeMapper">
+    <resultMap id="NoticeResultMap" type="com.yummy.yummytrip.notice.model.GetNoticeResponseDto">
+        <id column="notice_id" property="noticeId"/>
+        <result column="user_id" property="userId"/>
+        <result column="title" property="title"/>
+        <result column="content" property="content"/>
+        <result column="createdAt" property="createdAt"/>
+        <result column="modifiedAt" property="modifiedAt"/>
+    </resultMap>
+
     <insert id="insertNotice" parameterType="com.yummy.yummytrip.notice.model.NoticeCreateRequestDto">
         INSERT INTO notice (user_id, title, content, createdAt, modifiedAt)
         VALUES (#{userId}, #{title}, #{content}, NOW(), NOW())
     </insert>
 
-    <select id="getNoticeById" parameterType="long" resultType="com.yummy.yummytrip.notice.model.GetNoticeResponseDto">
+    <select id="getNoticeById" parameterType="long" resultMap="NoticeResultMap">
         SELECT notice_id, user_id, title, content, createdAt, modifiedAt
         FROM notice
         WHERE notice_id = #{noticeId}
     </select>
 
-    <select id="selectAllNotices" resultType="com.yummy.yummytrip.notice.model.GetNoticeResponseDto">
+    <select id="selectAllNotices" resultMap="NoticeResultMap">
         SELECT notice_id, user_id, title, content, createdAt, modifiedAt
         FROM notice
         ORDER BY createdAt DESC
@@ -24,7 +33,7 @@
     <update id="updateNotice" parameterType="com.yummy.yummytrip.notice.model.NoticeUpdateRequestDto">
         UPDATE notice
         SET title = #{title}, content = #{content}, modifiedAt = NOW()
-        WHERE notice_id = #{id}
+        WHERE notice_id = #{noticeId}
     </update>
 
     <delete id="deleteNotice" parameterType="long">

--- a/src/main/resources/mapper/notice.xml
+++ b/src/main/resources/mapper/notice.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.yummy.yummytrip.notice.mapper.NoticeMapper">
+    <insert id="insertNotice" parameterType="com.yummy.yummytrip.notice.model.NoticeCreateRequestDto">
+        INSERT INTO notice (user_id, title, content, createdAt, modifiedAt)
+        VALUES (#{userId}, #{title}, #{content}, NOW(), NOW())
+    </insert>
+
+    <select id="getNoticeById" parameterType="long" resultType="com.yummy.yummytrip.notice.model.GetNoticeResponseDto">
+        SELECT notice_id, user_id, title, content, createdAt, modifiedAt
+        FROM notice
+        WHERE notice_id = #{noticeId}
+    </select>
+
+    <select id="selectAllNotices" resultType="com.yummy.yummytrip.notice.model.GetNoticeResponseDto">
+        SELECT notice_id, user_id, title, content, createdAt, modifiedAt
+        FROM notice
+        ORDER BY createdAt DESC
+    </select>
+
+    <update id="updateNotice" parameterType="com.yummy.yummytrip.notice.model.NoticeUpdateRequestDto">
+        UPDATE notice
+        SET title = #{title}, content = #{content}, modifiedAt = NOW()
+        WHERE notice_id = #{id}
+    </update>
+
+    <delete id="deleteNotice" parameterType="long">
+        DELETE FROM notice
+        WHERE notice_id = #{noticeId}
+    </delete>
+</mapper>

--- a/src/main/resources/mapper/user.xml
+++ b/src/main/resources/mapper/user.xml
@@ -13,4 +13,21 @@
     <select id="findByEmail" parameterType="String" resultType="UserDto">
         select * from user where email = #{email}
     </select>
+
+    <update id="update" parameterType="UpdateDto">
+        update user set username = #{username}, password = #{password}, birth = #{birth}, userType = #{usertype}
+        where email = #{email}
+    </update>
+
+    <select id="findEmail" parameterType="UserDto" resultType="UserDto">
+        select * from user where username = #{username} and birth = #{birth}
+    </select>
+
+    <select id="findPassword" parameterType="UserDto" resultType="UserDto">
+        select * from user where username = #{username} and birth = #{birth} and email = #{email}
+    </select>
+
+    <update id="updatePassword" parameterType="UserDto">
+        update user set password = #{password} where email = #{email}
+    </update>
 </mapper>

--- a/src/main/resources/mapper/user.xml
+++ b/src/main/resources/mapper/user.xml
@@ -3,13 +3,22 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="com.yummy.yummytrip.user.mapper.UserMapper">
+    <resultMap id="userResultMap" type="UserDto">
+        <id property="userId" column="user_id"/>
+        <result property="username" column="username"/>
+        <result property="email" column="email"/>
+        <result property="password" column="password"/>
+        <result property="birth" column="birth"/>
+        <result property="usertype" column="userType"/>
+    </resultMap>
+
 
     <insert id="signUp" parameterType="UserDto">
         insert into user (username, email, password, birth, userType)
         values (#{username}, #{email}, #{password}, #{birth}, #{usertype})
     </insert>
 
-    <select id="findByEmail" parameterType="String" resultType="UserDto">
+    <select id="findByEmail" parameterType="String" resultMap="userResultMap">
         select * from user where email = #{email}
     </select>
 

--- a/src/main/resources/mapper/user.xml
+++ b/src/main/resources/mapper/user.xml
@@ -13,4 +13,8 @@
     <select id="findByEmail" parameterType="String" resultType="UserDto">
         select * from user where email = #{email}
     </select>
+
+    <delete id="signOut" parameterType="String">
+        delete from user where email = #{email}
+    </delete>
 </mapper>


### PR DESCRIPTION
## 🗂️ 이슈 연결
- #1 
- #2 
- #3 
- #13   (12인데 오타났어요.. 😢)  
- closes: #12  

</br>

## 📌 구현한 API
- 공지사항 작성 : `Post  /api/notice/add`
- 공지사항 단일 조회 : `GET  /api/notice/{noticeId}`
- 공지사항 전체 조회 : `GET  /api/notice/get`
- 공지사항 수정 : `Post  /api/notice/upadate`
- 공지사항 삭제 : `Delete  /api/notice/delete/{noticeId}`

</br>

## 📝 작업 사항
- 공지사항 CRUD 진행
- 관리자만 공지사항을 작성, 수정, 삭제할 수 있도록 기능 추가
- `CustomException`으로 예외 처리한 부분이 응답 Body에서 확인가능하도록 수정
- 회원가입시 null이 아닌 유효한 정보만 저장되도록 myBatis의 ResultMap을 이용해 수정
</br>
